### PR TITLE
fix/#4-handle-guzzle--null-response Response in guzzle exceptions can be null 

### DIFF
--- a/src/Client/ArtemeonHttpClient.php
+++ b/src/Client/ArtemeonHttpClient.php
@@ -16,7 +16,6 @@ namespace Artemeon\HttpClient\Client;
 use Artemeon\HttpClient\Client\Options\ClientOptions;
 use Artemeon\HttpClient\Client\Options\ClientOptionsConverter;
 use Artemeon\HttpClient\Exception\HttpClientException;
-use Artemeon\HttpClient\Exception\InvalidArgumentException;
 use Artemeon\HttpClient\Exception\Request\Http\ClientResponseException;
 use Artemeon\HttpClient\Exception\Request\Http\RedirectResponseException;
 use Artemeon\HttpClient\Exception\Request\Http\ResponseException;
@@ -122,6 +121,10 @@ class ArtemeonHttpClient implements HttpClient
             throw RuntimeException::fromGuzzleException($previous);
         }
 
+        if ($response === null) {
+           throw RuntimeException::fromString("Subsystem response is null");
+        }
+
         return $this->convertFromGuzzleResponse($response);
     }
 
@@ -129,7 +132,7 @@ class ArtemeonHttpClient implements HttpClient
      * Converts a GuzzleResponse object to our Response object
      *
      * @param GuzzleResponse $guzzleResponse
-     * @throws InvalidArgumentException
+     * @return Response
      */
     private function convertFromGuzzleResponse(GuzzleResponse $guzzleResponse): Response
     {

--- a/src/Client/ArtemeonHttpClient.php
+++ b/src/Client/ArtemeonHttpClient.php
@@ -34,6 +34,7 @@ use GuzzleHttp\Exception\BadResponseException as GuzzleBadResponseException;
 use GuzzleHttp\Exception\ClientException as GuzzleClientException;
 use GuzzleHttp\Exception\ConnectException as GuzzleConnectException;
 use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
+use GuzzleHttp\Exception\SeekException;
 use GuzzleHttp\Exception\ServerException as GuzzleServerException;
 use GuzzleHttp\Exception\TooManyRedirectsException as GuzzleTooManyRedirectsException;
 use GuzzleHttp\Exception\TransferException as GuzzleTransferException;
@@ -47,19 +48,12 @@ class ArtemeonHttpClient implements HttpClient
     private GuzzleClient $guzzleClient;
     private ClientOptionsConverter $clientOptionsConverter;
 
-    /**
-     * @param GuzzleClient $guzzleClient
-     * @param ClientOptionsConverter $clientOptionsConverter
-     */
     public function __construct(GuzzleClient $guzzleClient, ClientOptionsConverter $clientOptionsConverter)
     {
         $this->guzzleClient = $guzzleClient;
         $this->clientOptionsConverter = $clientOptionsConverter;
     }
 
-    /**
-     * @inheritDoc
-     */
     final public function send(Request $request, ClientOptions $clientOptions = null): Response
     {
         if ($clientOptions instanceof ClientOptions) {
@@ -81,17 +75,17 @@ class ArtemeonHttpClient implements HttpClient
      * Send request and transform Guzzle exception to Artemeon exceptions
      * Map Guzzle exceptions -> HttpClient exceptions:
      * ```
-     *  1. RuntimeException -> HttpClientException)
-     *      1. TransferException -> TransferException
-     *          1. RequestException ->  ResponseException
-     *              1. BadResponseException -> ResponseException
-     *                  1. ServerException -> ServerResponseException
-     *                  2. ClientException -> ClientResponseException
-     *              2. ConnectException -> ConnectException
-     *              3. TooManyRedirectsException -> RedirectResponseException
+     *  1. \RuntimeException -> RuntimeException (HttpClientException)
+     *      1. SeekException
+     *      2. GuzzleTransferException -> TransferException
+     *          1. GuzzleRequestException ->  ResponseException
+     *              1. GuzzleConnectException -> ConnectException
+     *              2. GuzzleTooManyRedirectsException -> RedirectResponseException
+     *              3. GuzzleBadResponseException -> ResponseException
+     *                  1. GuzzleServerException -> ServerResponseException
+     *                  2. GuzzleClientException -> ClientResponseException
      * ```
-     * @param Request $request
-     * @param array $guzzleOptions
+     *
      * @throws HttpClientException
      */
     private function doSend(Request $request, array $guzzleOptions): Response
@@ -99,42 +93,44 @@ class ArtemeonHttpClient implements HttpClient
         try {
             $response = $this->guzzleClient->send($request, $guzzleOptions);
         } catch (GuzzleClientException $previous) {
-            $response = $this->convertFromGuzzleResponse($previous->getResponse());
-            throw ClientResponseException::fromResponse($response, $request, $previous->getMessage(), $previous);
+            throw ClientResponseException::fromResponse($this->getResponseFromGuzzleException($previous), $request, $previous->getMessage(), $previous);
         } catch (GuzzleServerException $previous) {
-            $response = $this->convertFromGuzzleResponse($previous->getResponse());
-            throw ServerResponseException::fromResponse($response, $request, $previous->getMessage(), $previous);
+            throw ServerResponseException::fromResponse($this->getResponseFromGuzzleException($previous), $request, $previous->getMessage(), $previous);
         } catch (GuzzleBadResponseException $previous) {
-            $response = $this->convertFromGuzzleResponse($previous->getResponse());
-            throw ResponseException::fromResponse($response, $request, $previous->getMessage(), $previous);
+            throw ResponseException::fromResponse($this->getResponseFromGuzzleException($previous), $request, $previous->getMessage(), $previous);
+        } catch (GuzzleTooManyRedirectsException $previous) {
+            throw RedirectResponseException::fromResponse($this->getResponseFromGuzzleException($previous), $request, $previous->getMessage(), $previous);
         } catch (GuzzleConnectException $previous) {
             throw ConnectException::fromRequest($request, $previous->getMessage(), $previous);
-        } catch (GuzzleTooManyRedirectsException $previous) {
-            $response = $this->convertFromGuzzleResponse($previous->getResponse());
-            throw RedirectResponseException::fromResponse($response, $request, $previous->getMessage(), $previous);
-        } catch (GuzzleRequestException  $previous) {
-            $response = $this->convertFromGuzzleResponse($previous->getResponse());
-            throw ResponseException::fromResponse($response, $request, $previous->getMessage(), $previous);
+        } catch (GuzzleRequestException $previous) {
+            throw ResponseException::fromResponse($this->getResponseFromGuzzleException($previous), $request, $previous->getMessage(), $previous);
         } catch (GuzzleTransferException $previous) {
             throw TransferException::fromRequest($request, $previous->getMessage(), $previous);
+        } catch (SeekException $previous) {
+            throw RuntimeException::fromGuzzleException($previous);
         } catch (\RuntimeException $previous) {
             throw RuntimeException::fromGuzzleException($previous);
         }
 
-        if ($response === null) {
-           throw RuntimeException::fromString("Subsystem response is null");
+        return $this->convertGuzzleResponse($response);
+    }
+
+    /**
+     * Checks the Guzzle exception for a response object and converts it to a Artemeon response object
+     */
+    private function getResponseFromGuzzleException(GuzzleRequestException $guzzleRequestException): ?Response
+    {
+        if (!$guzzleRequestException->hasResponse()) {
+            return null;
         }
 
-        return $this->convertFromGuzzleResponse($response);
+        return $this->convertGuzzleResponse($guzzleRequestException->getResponse());
     }
 
     /**
      * Converts a GuzzleResponse object to our Response object
-     *
-     * @param GuzzleResponse $guzzleResponse
-     * @return Response
      */
-    private function convertFromGuzzleResponse(GuzzleResponse $guzzleResponse): Response
+    private function convertGuzzleResponse(GuzzleResponse $guzzleResponse): Response
     {
         $headers = Headers::create();
 

--- a/src/Exception/Request/Http/ResponseException.php
+++ b/src/Exception/Request/Http/ResponseException.php
@@ -23,20 +23,20 @@ use Exception;
  */
 class ResponseException extends TransferException
 {
-    protected Response $response;
+    protected ?Response $response;
     protected int $statusCode;
 
     /**
      * Named constructor to create an instance based on the response of the failed request
      *
-     * @param Response $response The failed response
+     * @param ?Response $response The failed response if exists
      * @param Request $request The failed request
      * @param string $message The error message
      * @param Exception|null $previous The previous exception
      * @return ResponseException
      */
     public static function fromResponse(
-        Response $response,
+        ?Response $response,
         Request $request,
         string $message,
         Exception $previous = null
@@ -52,9 +52,17 @@ class ResponseException extends TransferException
     /**
      * Returns the Response object
      */
-    public function getResponse(): Response
+    public function getResponse(): ?Response
     {
         return $this->response;
+    }
+
+    /**
+     * Checks if we have a response object
+     */
+    public function hasResponse(): bool
+    {
+        return $this->response instanceof Response;
     }
 
     /**

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -37,9 +37,4 @@ class RuntimeException extends \RuntimeException implements HttpClientException
     {
         return new self($exception->getMessage(), 0, $exception);
     }
-
-    public static function fromString(string $message): self
-    {
-        return new self($message);
-    }
 }

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -37,4 +37,9 @@ class RuntimeException extends \RuntimeException implements HttpClientException
     {
         return new self($exception->getMessage(), 0, $exception);
     }
+
+    public static function fromString(string $message): self
+    {
+        return new self($message);
+    }
 }

--- a/src/Http/MediaType.php
+++ b/src/Http/MediaType.php
@@ -49,7 +49,7 @@ class MediaType
     public const UNKNOWN = "application/octet-stream";
 
     /** @var string[] */
-    private static $extensionToType = [
+    private static array $extensionToType = [
         'json' => self::JSON,
         'pdf' => self::PDF,
         'xml' => self::XML,


### PR DESCRIPTION
Argument 1 passed to Artemeon\HttpClient\Client\ArtemeonHttpClient::convertFromGuzzleResponse() must be an instance of Psr\Http\Message\ResponseInterface, null given 