### PR TITLE
fix: Require psr/http-message v1 because of incompatibilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "guzzlehttp/guzzle": "~7.4",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "psr/log": "^1.1"
+    "psr/log": "^1.1",
+    "psr/http-message": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "9.*",


### PR DESCRIPTION
`psx/http` was the last restricting dependency inside the AGP, holding `psr/http-message` at `v1`. As @chriskapp opened up the `psr/http-message` version constraint from `^1.0` to `^1.0|^2.0` in [`psx/http`](https://github.com/apioo/psx-http/releases/tag/v4.1.0) a few hours ago, `psr/http-message:v2` was installed instead. `artemeon/http-client` was missing the required `psr/http-message` dependency and is incompatible with v2. Therefore we require `psr/http-message:v1` for now.

Because of `php-http/psr7-integration-tests` we cannot upgrade `psr/http-message` to `v2` though.