### PR TITLE
Feat/#22 strict oauth2 decorator

### DIFF
--- a/src/Client/Decorator/OAuth2/ClientCredentials.php
+++ b/src/Client/Decorator/OAuth2/ClientCredentials.php
@@ -37,6 +37,16 @@ class ClientCredentials
         $this->scope = mb_convert_encoding($scope, 'UTF-8', 'ISO-8859-1');
     }
 
+    public function getClientId(): string
+    {
+        return $this->clientId;
+    }
+
+    public function getClientSecret(): string
+    {
+        return $this->clientSecret;
+    }
+
     /**
      * Named constructor to create an instance based on the given credentials
      *
@@ -52,13 +62,16 @@ class ClientCredentials
     /**
      * Creates the required key => value pairs for the Access Token Request
      */
-    public function toArray(): array
+    public function toArray(bool $includeClientCredentials = true): array
     {
         $requestData = [
             'grant_type' => 'client_credentials',
-            'client_id' => $this->clientId,
-            'client_secret' => $this->clientSecret,
         ];
+
+        if ($includeClientCredentials) {
+            $requestData['client_id'] = $this->clientId;
+            $requestData['client_secret'] = $this->clientSecret;
+        }
 
         if (!empty($this->scope)) {
             $requestData['scope'] = $this->scope;

--- a/src/Client/Decorator/OAuth2/ClientCredentialsDecorator.php
+++ b/src/Client/Decorator/OAuth2/ClientCredentialsDecorator.php
@@ -87,12 +87,11 @@ class ClientCredentialsDecorator extends HttpClientDecorator
             $accessTokenCache = new InMemoryAccessTokenCache();
         }
 
+        $headers = Headers::create();
         if ($strictRfc) {
-            $headers = Headers::create();
             $headers->add(Header::fromField(Authorization::forAuthBasic($clientCredentials->getClientId(), $clientCredentials->getClientSecret())));
             $body = Body::fromEncoder(FormUrlEncoder::fromArray($clientCredentials->toArray(false)));
         } else {
-            $headers = Headers::create();
             $body = Body::fromEncoder(FormUrlEncoder::fromArray($clientCredentials->toArray()));
         }
 


### PR DESCRIPTION
Currently the `ClientCredentialsDecorator` send the `client_id` and `client_secret` in the Body, this does not strictly follow the OAuth2 spec s. https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.2 since we need to send the client_id and client_secret also as Basic-Auth header.
